### PR TITLE
Prevent React 'Invariant violation' errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const {JSDOM} = require('jsdom');
+const ExecutionEnvironment = require('fbjs/lib/ExecutionEnvironment');
 const {mount} = require('enzyme');
 
 module.exports = function mochaReactUtils ({domMarkup} = {}) {
@@ -7,6 +8,10 @@ module.exports = function mochaReactUtils ({domMarkup} = {}) {
     global.window = new JSDOM(domMarkup).window;
     global.document = window.document;
 
+    // Let React know there is a DOM to prevent 'Invariant Violation' errors from occurring.
+    // See https://stackoverflow.com/questions/26867535/calling-setstate-in-jsdom-based-tests-causing-cannot-render-markup-in-a-worker
+    ExecutionEnvironment.canUseDOM = true;
+
     // Add helper function for rendering a react element
     this.render = function (element) {
       return mount(element);
@@ -14,6 +19,9 @@ module.exports = function mochaReactUtils ({domMarkup} = {}) {
   });
 
   after(function () {
+    // Let React know DOM is no longer available.
+    ExecutionEnvironment.canUseDOM = true;
+
     // Tear down fake dom once tests are complete
     delete global.window;
     delete global.document;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react-addons-test-utils": "^15.6.0"
   },
   "peerDependencies": {
+    "fbjs": "^0.8.12",
     "mocha": "^3.4.2",
     "react": "^15.6.0",
     "react-dom": "^15.6.0"


### PR DESCRIPTION
While writing tests for this system I came across the good old Invariant Violation from React, which can be caused by loading React after creating a DOM with jsdom if you're doing things that React requires a DOM for (like simulating clicks or whatevs).

Turns out that React sets some global flag when it is loaded for the first time to determine if there is a DOM, which could be set to false if you create a DOM after requiring React. So we just have to set that flag to true after we create our fake DOM.