### PR TITLE
Return render method in an object instead of attaching to test context

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Utilities for testing React applications with Mocha. Includes [enzyme](https://w
   import reactUtils from 'underdog-mocha-react';
 
   describe('A sufficiently thorough test', function () {
-    // Injects a helper method for rendering elements with enzyme.mount, this.render().
+    // Returns a helper method for rendering elements with enzyme.mount, render().
     // Also creates a fake dom with jsdom, accessible from global.window.
-    reactUtils();
+    const {render} = reactUtils();
 
     it('confirms all the things', function () {
-      // Render component with this.render() to get an Enzyme wrapper via enzyme.mount().
-      const wrapper = this.render(
+      // Render component render() to get an Enzyme wrapper via enzyme.mount().
+      const wrapper = render(
         <a href="/test">Hey there</a>
       );
 

--- a/index.js
+++ b/index.js
@@ -11,19 +11,23 @@ module.exports = function mochaReactUtils ({domMarkup} = {}) {
     // Let React know there is a DOM to prevent 'Invariant Violation' errors from occurring.
     // See https://stackoverflow.com/questions/26867535/calling-setstate-in-jsdom-based-tests-causing-cannot-render-markup-in-a-worker
     ExecutionEnvironment.canUseDOM = true;
-
-    // Add helper function for rendering a react element
-    this.render = function (element) {
-      return mount(element);
-    };
   });
 
   after(function () {
     // Let React know DOM is no longer available.
-    ExecutionEnvironment.canUseDOM = true;
+    ExecutionEnvironment.canUseDOM = false;
 
     // Tear down fake dom once tests are complete
     delete global.window;
     delete global.document;
   });
+
+  // Create helper function for rendering a react element
+  const render = function (element) {
+    return mount(element);
+  };
+
+  return {
+    render
+  }
 }


### PR DESCRIPTION
Just assigning things to `this` is no bueno, as it could potentially cause conflicts. Returning an object instead is probably better. 