### PR TITLE
Add helper for simulating DOM events

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Utilities for testing React applications with Mocha. Includes [enzyme](https://w
   describe('A sufficiently thorough test', function () {
     // Returns a helper method for rendering elements with enzyme.mount, render().
     // Also creates a fake dom with jsdom, accessible from global.window.
-    const {render} = reactUtils();
+    const {render, simulateDOMEvent} = reactUtils();
 
     it('confirms all the things', function () {
       // Render component render() to get an Enzyme wrapper via enzyme.mount().
@@ -31,6 +31,11 @@ Utilities for testing React applications with Mocha. Includes [enzyme](https://w
       // You also get a fake window object for your tests.
       // This is useful for simulating events with wrapper.find('...').simulate().
       assert.notEqual(typeof window, 'undefined');
+
+      // Test how your component reacts to DOM events with simulateDOMEvent()
+      simulateDOMEvent(document, 'keydown', {
+        keyCode: 27
+      });
     });
   });
   ```

--- a/index.js
+++ b/index.js
@@ -27,7 +27,21 @@ module.exports = function mochaReactUtils ({domMarkup} = {}) {
     return mount(element);
   };
 
+  // Helper for simulating DOM events
+  // https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events
+  // eventTarget: The node to simulate the event for
+  // eventType: The type of the event ('scroll', 'click', etc)
+  const simulateDOMEvent = function (eventTarget, eventType, eventData) {
+    const event = document.createEvent('HTMLEvents');
+    event.initEvent(eventType, true, true);
+    Object.keys(eventData).forEach((key) => {
+      event[key] = eventData[key];
+    });
+    eventTarget.dispatchEvent(event);
+  }
+
   return {
-    render
+    render,
+    simulateDOMEvent
   }
 }


### PR DESCRIPTION
This is useful for testing event listeners that are typically added to `document`, like `keydown`.